### PR TITLE
feat: add exact-turn profiling scenario

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -94,6 +94,7 @@ pub fn build(b: *std.Build) void {
     });
     profiler.root_module.addImport("card", card_mod);
     profiler.root_module.addImport("evaluator", evaluator_mod);
+    profiler.root_module.addImport("poker", poker_mod);
 
     const profiler_run = b.addRunArtifact(profiler);
     if (b.args) |args| {


### PR DESCRIPTION
Adds profiling support for exact equity calculations on turn boards.

## Changes
- Add `exact-turn` scenario to profile_main.zig
- Import poker module in profiler build configuration
- Enables profiling of exact enumeration hot paths

## Usage
```bash
task profile SCENARIO=exact-turn ITERATIONS=50000
```

## Context
This profiling scenario was added while investigating the exact_turn benchmark regression, which revealed SIMD lane waste and allocation overhead issues. The profiling capability will help identify similar bottlenecks in future optimizations.

Matches the benchmark scenario: AA vs KK on turn (4 cards), enumerating 44 possible rivers.