### PR TITLE
feat: add multiway showdown helpers and deck sampler

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,12 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/card.zig"),
     });
 
+    // Level 1.5: Deck utilities (depends on card)
+    const deck_mod = b.addModule("deck", .{
+        .root_source_file = b.path("src/deck.zig"),
+    });
+    deck_mod.addImport("card", card_mod);
+
     // Level 2: Evaluator module (depends on card)
     const evaluator_mod = b.addModule("evaluator", .{
         .root_source_file = b.path("src/evaluator.zig"),
@@ -34,6 +40,7 @@ pub fn build(b: *std.Build) void {
     });
     equity_mod.addImport("card", card_mod);
     equity_mod.addImport("evaluator", evaluator_mod);
+    equity_mod.addImport("deck", deck_mod);
 
     // Level 4: Range module (depends on card, hand, equity)
     const range_mod = b.addModule("range", .{
@@ -75,6 +82,7 @@ pub fn build(b: *std.Build) void {
     poker_mod.addImport("analysis", analysis_mod);
     poker_mod.addImport("draws", draws_mod);
     poker_mod.addImport("heads_up", heads_up_mod);
+    poker_mod.addImport("deck", deck_mod);
 
     // Tools module (depends on poker for benchmarking)
     const tools_mod = b.addModule("tools", .{
@@ -249,6 +257,18 @@ pub fn build(b: *std.Build) void {
     const run_card_tests = b.addRunArtifact(card_tests);
     test_step.dependOn(&run_card_tests.step);
 
+    // Deck module tests (depends on card)
+    const deck_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/deck.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    deck_tests.root_module.addImport("card", card_mod);
+    const run_deck_tests = b.addRunArtifact(deck_tests);
+    test_step.dependOn(&run_deck_tests.step);
+
     // Evaluator module tests (depends on card)
     const evaluator_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -300,6 +320,7 @@ pub fn build(b: *std.Build) void {
     });
     equity_tests.root_module.addImport("card", card_mod);
     equity_tests.root_module.addImport("evaluator", evaluator_mod);
+    equity_tests.root_module.addImport("deck", deck_mod);
     const run_equity_tests = b.addRunArtifact(equity_tests);
     test_step.dependOn(&run_equity_tests.step);
 
@@ -358,6 +379,7 @@ pub fn build(b: *std.Build) void {
     poker_tests.root_module.addImport("analysis", analysis_mod);
     poker_tests.root_module.addImport("draws", draws_mod);
     poker_tests.root_module.addImport("heads_up", heads_up_mod);
+    poker_tests.root_module.addImport("deck", deck_mod);
     const run_poker_tests = b.addRunArtifact(poker_tests);
     test_step.dependOn(&run_poker_tests.step);
 }

--- a/src/deck.zig
+++ b/src/deck.zig
@@ -1,0 +1,123 @@
+const std = @import("std");
+const card = @import("card");
+
+/// Full ordered deck of 52 unique cards encoded as single-bit masks.
+pub const FULL_DECK = blk: {
+    var deck: [52]card.Hand = undefined;
+    for (0..52) |i| {
+        deck[i] = @as(card.Hand, 1) << @intCast(i);
+    }
+    break :blk deck;
+};
+
+/// Swap-remove sampler for drawing cards without replacement.
+/// Copies the static FULL_DECK into an internal buffer so we can perform
+/// O(1) draw operations that keep the remaining portion contiguous.
+pub const DeckSampler = struct {
+    cards: [52]card.Hand = FULL_DECK,
+    remaining: u8 = 52,
+
+    /// Create a sampler seeded with the full deck.
+    pub fn init() DeckSampler {
+        return DeckSampler{
+            .cards = FULL_DECK,
+            .remaining = 52,
+        };
+    }
+
+    /// Reset to a full deck (no exclusions).
+    pub fn reset(self: *DeckSampler) void {
+        self.cards = FULL_DECK;
+        self.remaining = 52;
+    }
+
+    /// Reset to a deck that excludes the provided mask of cards.
+    pub fn resetWithMask(self: *DeckSampler, exclude_mask: card.Hand) void {
+        self.reset();
+        if (exclude_mask == 0) return;
+        self.removeMask(exclude_mask);
+    }
+
+    /// Remove every card contained in `mask` (one bit per card).
+    pub fn removeMask(self: *DeckSampler, mask: card.Hand) void {
+        var remaining = mask;
+        while (remaining != 0) {
+            const bit_index: u6 = @intCast(@ctz(remaining));
+            const card_mask = @as(card.Hand, 1) << bit_index;
+            self.removeCard(card_mask);
+            remaining &= remaining - 1;
+        }
+    }
+
+    /// Remove a single specific card from the deck.
+    pub fn removeCard(self: *DeckSampler, card_mask: card.Hand) void {
+        std.debug.assert(card.countCards(card_mask) == 1);
+        const maybe_index = findIndex(self, card_mask);
+        std.debug.assert(maybe_index != null);
+        const index = maybe_index.?;
+
+        self.remaining -= 1;
+        std.mem.swap(card.Hand, &self.cards[index], &self.cards[self.remaining]);
+    }
+
+    /// Draw a single card using swap-remove. `rng` must expose `uintLessThan`.
+    pub fn draw(self: *DeckSampler, rng: anytype) card.Hand {
+        std.debug.assert(self.remaining > 0);
+        const idx = rng.uintLessThan(u8, self.remaining);
+        self.remaining -= 1;
+        std.mem.swap(card.Hand, &self.cards[idx], &self.cards[self.remaining]);
+        return self.cards[self.remaining];
+    }
+
+    /// Draw multiple cards into `out` without replacement.
+    pub fn drawMany(self: *DeckSampler, rng: anytype, out: []card.Hand) void {
+        std.debug.assert(out.len <= self.remaining);
+        for (out) |*slot| {
+            slot.* = self.draw(rng);
+        }
+    }
+
+    /// Draw `count` cards and return the combined bitmask.
+    pub fn drawMask(self: *DeckSampler, rng: anytype, count: u8) card.Hand {
+        if (count == 0) return 0;
+        std.debug.assert(count <= self.remaining);
+
+        var result: card.Hand = 0;
+        var i: u8 = 0;
+        while (i < count) : (i += 1) {
+            result |= self.draw(rng);
+        }
+        return result;
+    }
+
+    /// Number of cards still available for drawing.
+    pub fn remainingCards(self: DeckSampler) u8 {
+        return self.remaining;
+    }
+};
+
+fn findIndex(sampler: *DeckSampler, target: card.Hand) ?usize {
+    const active = sampler.cards[0..sampler.remaining];
+    for (active, 0..) |card_mask, idx| {
+        if (card_mask == target) return idx;
+    }
+    return null;
+}
+
+const testing = std.testing;
+
+test "DeckSampler supports exclusions and unique draws" {
+    var prng = std.Random.DefaultPrng.init(0xDEADBEEF);
+    const rng = prng.random();
+
+    var sampler = DeckSampler.init();
+    // Remove two known cards.
+    sampler.removeMask(card.makeCard(.spades, .ace) | card.makeCard(.hearts, .ace));
+    try testing.expectEqual(@as(u8, 50), sampler.remainingCards());
+
+    // Draw two distinct cards and ensure they are unique.
+    const first = sampler.draw(rng);
+    const second = sampler.draw(rng);
+    try testing.expect((first & second) == 0);
+    try testing.expectEqual(@as(u8, 48), sampler.remainingCards());
+}

--- a/src/poker.zig
+++ b/src/poker.zig
@@ -23,6 +23,7 @@ pub const equity = @import("equity");
 const analysis = @import("analysis");
 const draws = @import("draws");
 const heads_up_mod = @import("heads_up");
+const deck = @import("deck");
 
 // === CORE TYPES ===
 
@@ -113,6 +114,15 @@ pub const evaluateShowdownWithContext = evaluator.evaluateShowdownWithContext;
 /// Evaluate many showdowns sharing the same board context
 pub const evaluateShowdownBatch = evaluator.evaluateShowdownBatch;
 
+/// Result of evaluating multiple seats simultaneously
+pub const MultiwayResult = evaluator.MultiwayResult;
+
+/// Evaluate all seats at once, returning best rank, winner mask, and tie count
+pub const evaluateShowdownMultiway = evaluator.evaluateShowdownMultiway;
+
+/// Produce per-seat normalized equities for a shared board context
+pub const evaluateEquityWeights = evaluator.evaluateEquityWeights;
+
 // === HAND COMBINATIONS ===
 
 /// Generate all suited combinations for two ranks
@@ -187,6 +197,14 @@ pub const HeadsUpEquity = heads_up_mod.HeadsUpEquity;
 /// Pre-computed equity vs random opponent for all 169 hands
 /// Used as baseline for fast approximations
 pub const PREFLOP_VS_RANDOM = heads_up_mod.PREFLOP_VS_RANDOM;
+
+// === DECK UTILITIES ===
+
+/// Ordered 52-card deck encoded as single-bit masks
+pub const FULL_DECK = deck.FULL_DECK;
+
+/// Swap-remove sampler for fast card draws without replacement
+pub const DeckSampler = deck.DeckSampler;
 
 // === BENCHMARKING ===
 


### PR DESCRIPTION
## Summary
- add evaluateShowdownMultiway / evaluateEquityWeights helpers and expose through public API
- refactor Monte Carlo multiway to use new helpers and swap-remove DeckSampler utilities
- document usage, add multiway benchmark suite, and extend profiler to cover the helpers

## Testing
- zig build test
- task bench -- --filter multiway
- task profile SCENARIO=multiway