### PR TITLE
chore: refresh performance baselines for m5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Zig Poker Evaluator
 
-High-performance 7-card poker hand evaluator achieving ~3.3ns per hand evaluation on Apple M1.
+High-performance 7-card poker hand evaluator achieving ~2.0ns per hand evaluation on MacBook Pro (M5).
 
 ## Features
 
-- **Ultra-fast evaluation**: ~3.3ns per hand using CHD perfect hash tables and SIMD batch processing
+- **Ultra-fast evaluation**: ~2.0ns per hand using CHD perfect hash tables and SIMD batch processing
 - **SIMD optimization**: Batch evaluation of 32 hands simultaneously
 - **Equity calculations**: Monte Carlo and exact enumeration
 - **Range parsing**: Standard poker notation (AA, KK, AKs, etc.)
@@ -299,11 +299,11 @@ task run -- equity "AhAs" "KdKc"
 
 ## Performance
 
-Apple M1 results:
+- MacBook Pro (M5) results:
 
-- Single evaluation: ~3.3ns per hand
-- Batch evaluation: 306M hands/second
-- Speedup: 3.65× from baseline (11.95ns → 3.27ns)
+- Single evaluation: ~4.9ns per hand (~205M hands/second)
+- Batch evaluation: 500M hands/second (~2.0ns per hand)
+- Speedup: 6.0× from baseline (11.95ns → 2.00ns)
 - Memory: ~395KB lookup tables (267KB CHD + 128KB flush patterns)
 
 ## Documentation

--- a/benchmark-baseline-release-fast.json
+++ b/benchmark-baseline-release-fast.json
@@ -1,10 +1,10 @@
 {
   "version": "1.0",
-  "commit": "v3.1.0-4-gf9655a0e2d77",
-  "timestamp": "2025-10-12T06:19:30Z",
+  "commit": "v3.6.1-0-g25f53880dfc3",
+  "timestamp": "2025-10-30T03:33:29Z",
   "system": {
-    "hostname": "Alexandra.local",
-    "cpu": "Apple M1",
+    "hostname": "Clynelish.local",
+    "cpu": "Apple M5",
     "arch": "aarch64",
     "os": "macos",
     "build_mode": "ReleaseFast"
@@ -13,65 +13,79 @@
     "eval": {
       "single_evaluation": {
         "unit": "ns/hand",
-        "value": 10.258708500000001,
+        "value": 4.8850204999999995,
         "runs": 100,
-        "cv": 0.003607885153962062
+        "cv": 0.007882361927614906
       },
       "batch_evaluation": {
         "unit": "ns/hand",
-        "value": 3.33140640625,
+        "value": 1.99791015625,
         "runs": 100,
-        "cv": 0.0013291738535902108
+        "cv": 0.006134297997988995
       }
     },
     "context": {
       "hole_evaluation": {
         "unit": "ns/eval",
-        "value": 8.9441875,
+        "value": 4.9747495,
         "runs": 100,
-        "cv": 0.0015350067760910066
+        "cv": 0.0053279527047553656
       },
       "init_board": {
         "unit": "ns/call",
-        "value": 10.880437,
+        "value": 6.3815625,
         "runs": 100,
-        "cv": 0.00622330197269076
+        "cv": 0.005446106401771291
       }
     },
     "showdown": {
       "context_path": {
         "unit": "ns/eval",
-        "value": 16.752625000000002,
+        "value": 11.006021,
         "runs": 100,
-        "cv": 0.004188699527214579
+        "cv": 0.003182116954441371
       },
       "batched": {
         "unit": "ns/eval",
-        "value": 7.2196045,
+        "value": 4.539187500000001,
         "runs": 100,
-        "cv": 0.0014683054090527119
+        "cv": 0.0069099415366696785
+      }
+    },
+    "multiway": {
+      "showdown_multiway": {
+        "unit": "ns/eval",
+        "value": 24.860937999999997,
+        "runs": 100,
+        "cv": 0.0027801171735143326
+      },
+      "equity_weights": {
+        "unit": "ns/eval",
+        "value": 34.140021,
+        "runs": 100,
+        "cv": 0.00563663774184635
       }
     },
     "range": {
       "equity_monte_carlo": {
         "unit": "ms/calc",
-        "value": 0.12559229500000002,
+        "value": 0.0837425,
         "runs": 100,
-        "cv": 0.0012238659642182365
+        "cv": 0.00509533450955023
       }
     },
     "equity": {
       "monte_carlo": {
         "unit": "µs/calc",
-        "value": 443.929,
+        "value": 282.022,
         "runs": 100,
-        "cv": 0.011896717437744023
+        "cv": 0.003493139503769855
       },
       "exact_turn": {
         "unit": "µs/calc",
-        "value": 0.314417725,
+        "value": 0.20042292499999997,
         "runs": 100,
-        "cv": 0.0011293544285985587
+        "cv": 0.00688986571267605
       }
     }
   }

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The evaluator achieves ~3.3ns per hand on Apple M1 through CHD perfect hash tables and SIMD batch processing.
+The evaluator achieves ~2.0ns per hand on MacBook Pro (M5) through CHD perfect hash tables and SIMD batch processing.
 
 ## Hand Representation
 
@@ -170,10 +170,10 @@ inline for (0..13) |rank| {
 
 ## Performance Characteristics
 
-**Apple M1:**
-- Single evaluation: ~3.3ns per hand
-- Batch evaluation (32 hands): ~3.3ns per hand
-- Throughput: 306M+ hands/second
+**MacBook Pro (M5):**
+- Single evaluation: ~4.9ns per hand
+- Batch evaluation (32 hands): ~2.0ns per hand
+- Throughput: 500M+ hands/second
 
 **Memory access:**
 1. CHD displacement lookup: 1 byte from 8KB (L1 hit)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -34,66 +34,71 @@ zig build -Doptimize=ReleaseFast
 🚀 Running Benchmarks
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Build mode: ReleaseFast
-Version:    v2.9.0-3-g6a1e5ae69524
+Version:    v3.6.1-0-g25f53880dfc3
+Mode:       Baseline (100 runs per benchmark)
 
-[1/4] eval
-  • batch_evaluation: 3.04 ns/hand (329.62M/s)
-[2/4] showdown
-  • context_path: 30.13 ns/eval (33.19M/s)
-  • batched: 7.22 ns/eval (138.52M/s)
-[3/4] equity
-  • monte_carlo: 439.69 µs/calc (2.27/s)
-  • exact_turn: 4.30 µs/calc (231.85/s)
-[4/4] range
-  • equity_monte_carlo: 123.30 ms/calc (0.01/s)
+[1/6] eval
+  • batch_evaluation: 2.00 ns/hand (500.52M/s)
+  • single_evaluation: 4.89 ns/hand (204.71M/s)
+[2/6] context
+  • init_board: 6.38 ns/call (6.38 ns/call)
+  • hole_evaluation: 4.97 ns/eval (201.02M/s)
+[3/6] showdown
+  • context_path: 11.01 ns/eval (90.86M/s)
+  • batched: 4.54 ns/eval (220.30M/s)
+[4/6] multiway
+  • showdown_multiway: 24.86 ns/eval (40.22M/s)
+  • equity_weights: 34.14 ns/eval (29.29M/s)
+[5/6] equity
+  • monte_carlo: 282.02 µs/calc (3.55K/s)
+  • exact_turn: 0.20 µs/calc (4.99M/s)
+[6/6] range
+  • equity_monte_carlo: 0.08 ms/calc (11.94K/s)
 
-📊 Comparison vs Baseline
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-✓ No significant changes
-
-✅ PASSED
+✅ Baseline saved to benchmark-baseline-release-fast.json
 ```
 
-### Results (Apple M1)
+### Results (MacBook Pro M5)
 
-**Single vs Batch:**
-```
-Batch Size | ns/hand | Million hands/sec | Speedup
------------|---------|-------------------|--------
-         1 |    8.67 |             115.4 |   1.00x
-        32 |    4.46 |             224.3 |   1.94x
-```
+All measurements below use `zig build bench --baseline` on October 30, 2025 with `-Doptimize=ReleaseFast`. Throughput conversions use 1,000/ns and round to the nearest integer.
 
-**Batch Size Scaling:**
-```
-Batch Size | ns/hand | Million hands/sec | Speedup
------------|---------|-------------------|--------
-         2 |    7.22 |             138.5 |   1.20x
-         4 |    6.07 |             164.8 |   1.43x
-         8 |    5.44 |             183.8 |   1.59x
-        16 |    4.85 |             206.2 |   1.79x
-        32 |    4.46 |             224.3 |   1.94x
-        64 |    4.31 |             232.0 |   2.01x
-```
+**Evaluator**
 
-**Showdown Benchmark:**
-```
-Scenario         | ns/eval | Comparisons/sec | Speedup
------------------|---------|-----------------|--------
-Context path     |  41.92  |       23.9M     |  1.00x
-Batched (32 max) |  13.42  |       74.5M     |  3.12x
-```
+| Metric | Time (ns/hand) | Throughput |
+| --- | --- | --- |
+| Single evaluation (scalar) | 4.89 | 205M hands/s |
+| Batch evaluation (32 hands) | 2.00 | 501M hands/s |
 
-**Equity Calculations:**
-```
-Scenario           | Simulations | Time (ms) | Sims/sec (M)
--------------------|-------------|-----------|-------------
-Preflop (no board) |      10000  |     12.45 |        0.803
-Flop (3 cards)     |       5000  |      8.23 |        0.608
-Turn (4 cards)     |       2000  |      3.89 |        0.514
-River (5 cards)    |       1000  |      2.11 |        0.474
-```
+**Context Setup**
+
+| Metric | Time | Throughput |
+| --- | --- | --- |
+| init_board | 6.38 ns/call | 157M calls/s |
+| hole_evaluation | 4.97 ns/eval | 201M eval/s |
+
+**Showdown**
+
+| Metric | Time | Throughput |
+| --- | --- | --- |
+| context_path | 11.01 ns/eval | 91M eval/s |
+| batched (32 lanes) | 4.54 ns/eval | 220M eval/s |
+
+**Multiway**
+
+| Metric | Time | Throughput |
+| --- | --- | --- |
+| showdown_multiway | 24.86 ns/eval | 40M eval/s |
+| equity_weights | 34.14 ns/eval | 29M eval/s |
+
+**Equity and Range**
+
+| Metric | Time | Throughput |
+| --- | --- | --- |
+| monte_carlo | 282.02 µs/calc | 3.55K calc/s |
+| exact_turn | 0.20 µs/calc | 5.0M calc/s |
+| range equity_monte_carlo | 0.0837 ms/calc | 11.9K calc/s |
 
 ### Benchmark Methodology
 
@@ -257,7 +262,7 @@ uniprof visualize /tmp/after.json
 **macOS:**
 - Uniprof uses native Instruments sampling
 - No special performance modes needed on Apple Silicon
-- Thermal throttling rarely an issue with M1 efficiency
+- Thermal throttling rarely an issue with M5 efficiency cores
 
 **Linux:**
 - Uniprof uses `perf`
@@ -282,7 +287,7 @@ uniprof visualize /tmp/after.json
 - Solution: Fewer background processes
 - Check: `pmset -g thermlog` for thermal state
 
-**Performance below target (~3.3ns/hand on M1):**
+**Performance below target (~2.0ns/hand on MacBook Pro M5):**
 - Wrong build flags (not using ReleaseFast)
 - Debug build accidentally used
 - Flush-heavy test data (should be < 0.4%)


### PR DESCRIPTION
## Summary
- update public docs with MacBook Pro M5 performance metrics
- regenerate ReleaseFast benchmark baseline on the new hardware

## Testing
- zig build test
- task bench -- --baseline