### PR TITLE
feat: add handStrength for showdown percentile calculation

### DIFF
--- a/src/poker.zig
+++ b/src/poker.zig
@@ -184,6 +184,10 @@ pub const heroVsFieldMonteCarlo = equity.heroVsFieldMonteCarlo;
 /// Example: equityVsRandom([As,Ks], [Kd,7c,2s], 10000, rng, allocator)
 pub const equityVsRandom = equity.equityVsRandom;
 
+/// Hand strength percentile - what % of opponent hands we beat at showdown
+/// Example: handStrength([Ah,Kh], [Qh,Jh,2h,7c,3d], allocator)
+pub const handStrength = equity.handStrength;
+
 // === HEADS-UP EQUITY TABLES ===
 
 /// Represents one of the 169 unique starting hands in Texas Hold'em


### PR DESCRIPTION
Adds `handStrength(hero, board, allocator)` which exhaustively computes what fraction of possible opponent hands we beat at showdown.

## Use Case
Useful for HUDs and analysis tools to answer: "What % of hands am I beating?"

## Implementation
- Requires complete 5-card board (river analysis only)
- Enumerates all 990 possible opponent hand combos (C(45,2))
- Uses board context optimization for fast evaluation
- Returns exact `EquityResult` with win/tie percentages

## Example
```zig
const result = try poker.handStrength(
    poker.parseHand("AhKh"),
    &.{ poker.parseCard("Qh"), poker.parseCard("Jh"), poker.parseCard("2h"),
        poker.parseCard("7c"), poker.parseCard("3d") },
    allocator,
);
// Nut flush beats ~99% of hands
```