### PR TITLE
fix: correct MAX_RANK to match CATEGORY_STEP encoding

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -288,7 +288,8 @@ const EvalCommand = struct {
         ansi.printGreen("Hand category: {}\n", .{category});
 
         // Show relative strength (lower rank = stronger)
-        const strength_pct = (7462.0 - @as(f64, @floatFromInt(rank))) / 7462.0 * 100.0;
+        const max_rank: f64 = @floatFromInt(poker.features.HandFeatures.MAX_RANK);
+        const strength_pct = (max_rank - @as(f64, @floatFromInt(rank))) / max_rank * 100.0;
         ansi.printCyan("Strength:      {d:.1}% (stronger than {d:.1}% of hands)\n", .{ strength_pct, strength_pct });
 
         if (opts.verbose) {


### PR DESCRIPTION
## Summary

Fixes incorrect `MAX_RANK` value that caused strength field to be clamped incorrectly for pairs and high-cards.

## Problem

`MAX_RANK` was set to 7462 (the classic "7462 distinct hand rankings" count), but the evaluator uses `CATEGORY_STEP=4096` encoding:
- Straight flush: category 0 (ranks 0-4095)
- Pair: category 7 (ranks ~28672+)
- High-card: category 8 (ranks up to 34054)

Any rank >7462 was clamped, resulting in near-zero strength for all pairs and high-cards.

## Fix

- `MAX_RANK` = `8 * 4096 + 1286` = 34054 (correct max for high-card category)
- Simplified strength calculation: rank 0 → 1.0, MAX_RANK → 0.0
- CLI now uses `HandFeatures.MAX_RANK` instead of hardcoded 7462
- Added test validating pair of aces has strength in expected range

## Testing

```bash
zig build test --summary all  # 144 tests pass
```

Reported by downstream consumer.